### PR TITLE
Adjust script to work without specified air mass flow rate

### DIFF
--- a/2phase_evaporator_extended_HE.py
+++ b/2phase_evaporator_extended_HE.py
@@ -110,8 +110,14 @@ ca_out.set_attr(T=T_air + 15)
 
 # solving
 mode = 'design'
-file = 'yangyi_evaporator_new'
+save_path = '2phase_eva_extended_yangyi_stable'
 # solve the network, print the results to prompt and save
 nw.solve(mode=mode)
 nw.print_results()
-#nw.save(file)
+nw.save(save_path)
+
+ca_in.set_attr(m=np.nan)
+ihe.set_attr(ttd_u=10)
+
+nw.solve(mode=mode, init_path=save_path)
+nw.print_results()


### PR DESCRIPTION
The internal heat exchanger for heat recovery adds an additional degree of freedom. Specifying e. g. the terminal temperature difference or one of the temperatures around the heat exchanger, will make the air mass flow a result.